### PR TITLE
Partial fill orders

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -17,7 +17,7 @@ optimizer = true
 # The number of optimizer runs
 optimizer_runs = 200
 # Whether or not to use the Yul intermediate representation compilation pipeline
-via_ir = false
+via_ir = true
 # Override the Solidity version (this overrides `auto_detect_solc`)
 solc_version = '0.8.12'
 

--- a/src/contracts/Bridgeless.sol
+++ b/src/contracts/Bridgeless.sol
@@ -25,9 +25,9 @@ contract Bridgeless is
     mapping(uint256 => uint256) public partialFillOrderActiveBitMap;
 
     function partialFillOrderIsActive(bytes32 orderHash) public view returns (bool) {
-        uint256 index = (uint256(orderHash) >> 8);
+        uint256 bucket = (uint256(orderHash) >> 8);
         uint256 mask = 1 << ((uint256(orderHash) & 0xff));
-        return ((partialFillOrderActiveBitMap[index] & mask) != 0);
+        return ((partialFillOrderActiveBitMap[bucket] & mask) != 0);
     }
 
     // Check an order deadline. Orders must be executed at or before the UTC timestamp specified by their `deadline`.
@@ -161,9 +161,9 @@ contract Bridgeless is
     function _createPartialFillStorage(BridgelessOrder calldata order, uint256 tokensTransferredOut, uint256 tokensObtained) internal {
         // set the storage slot
         bytes32 newOrderHash = calculateBridgelessOrderHash_PartialFill(order, tokensTransferredOut, tokensObtained);
-        uint256 index = (uint256(newOrderHash) >> 8);
+        uint256 bucket = (uint256(newOrderHash) >> 8);
         uint256 mask = 1 << ((uint256(newOrderHash) & 0xff));
-        partialFillOrderActiveBitMap[index] = (partialFillOrderActiveBitMap[index] | mask);
+        partialFillOrderActiveBitMap[bucket] = (partialFillOrderActiveBitMap[bucket] | mask);
         // emit an event
         emit PartialFillStorageCreated(newOrderHash, order, tokensTransferredOut, tokensObtained);
     }
@@ -418,14 +418,14 @@ contract Bridgeless is
         // calculate the orderHash
         bytes32 orderHash = calculateBridgelessOrderHash(order);
         // verify that `orderHash` is 'active' (i.e. its bit flag is set to '1' in the `partialFillOrderActiveBitMap`)
-        uint256 index = (uint256(orderHash) >> 8);
+        uint256 bucket = (uint256(orderHash) >> 8);
         uint256 mask = 1 << ((uint256(orderHash) & 0xff));
         require(
-            (partialFillOrderActiveBitMap[index] & mask != 0),
+            (partialFillOrderActiveBitMap[bucket] & mask != 0),
             "Bridgeless._markAsNoLongerActive: partialFillOrder not active at orderHash"
         );
         // mark the `orderHash` as no longer 'active'
-        partialFillOrderActiveBitMap[index] = partialFillOrderActiveBitMap[index] & (~mask);
+        partialFillOrderActiveBitMap[bucket] = partialFillOrderActiveBitMap[bucket] & (~mask);
     }
 
     /**

--- a/src/contracts/Bridgeless.sol
+++ b/src/contracts/Bridgeless.sol
@@ -25,8 +25,8 @@ contract Bridgeless is
     mapping(uint256 => uint256) public partialFillOrderActiveBitMap;
 
     function partialFillOrderIsActive(bytes32 orderHash) public view returns (bool) {
-        uint256 index = (uint256(orderHash) >> 8);
-        uint256 mask = 1 << ((uint256(orderHash) & 0xff));
+        uint256 index = (uint256(orderHash) >> 128);
+        uint256 mask = 1 << ((uint256(orderHash) & 0xffffffffffffffff));
         return ((partialFillOrderActiveBitMap[index] & mask) != 0);
     }
 
@@ -161,8 +161,8 @@ contract Bridgeless is
     function _createPartialFillStorage(BridgelessOrder calldata order, uint256 tokensTransferredOut, uint256 tokensObtained) internal {
         // set the storage slot
         bytes32 newOrderHash = calculateBridgelessOrderHash_PartialFill(order, tokensTransferredOut, tokensObtained);
-        uint256 index = (uint256(newOrderHash) >> 8);
-        uint256 mask = 1 << ((uint256(newOrderHash) & 0xff));
+        uint256 index = (uint256(newOrderHash) >> 128);
+        uint256 mask = 1 << ((uint256(newOrderHash) & 0xffffffffffffffff));
         partialFillOrderActiveBitMap[index] = (partialFillOrderActiveBitMap[index] | mask);
         // emit an event
         emit PartialFillStorageCreated(newOrderHash, order, tokensTransferredOut, tokensObtained);
@@ -418,8 +418,8 @@ contract Bridgeless is
         // calculate the orderHash
         bytes32 orderHash = calculateBridgelessOrderHash(order);
         // verify that `orderHash` is 'active' (i.e. its bit flag is set to '1' in the `partialFillOrderActiveBitMap`)
-        uint256 index = (uint256(orderHash) >> 8);
-        uint256 mask = 1 << ((uint256(orderHash) & 0xff));
+        uint256 index = (uint256(orderHash) >> 128);
+        uint256 mask = 1 << ((uint256(orderHash) & 0xffffffffffffffff));
         require(
             (partialFillOrderActiveBitMap[index] & mask != 0),
             "Bridgeless._markAsNoLongerActive: partialFillOrder not active at orderHash"

--- a/src/contracts/Bridgeless.sol
+++ b/src/contracts/Bridgeless.sol
@@ -25,8 +25,8 @@ contract Bridgeless is
     mapping(uint256 => uint256) public partialFillOrderActiveBitMap;
 
     function partialFillOrderIsActive(bytes32 orderHash) public view returns (bool) {
-        uint256 index = (uint256(orderHash) >> 128);
-        uint256 mask = 1 << ((uint256(orderHash) & 0xffffffffffffffff));
+        uint256 index = (uint256(orderHash) >> 8);
+        uint256 mask = 1 << ((uint256(orderHash) & 0xff));
         return ((partialFillOrderActiveBitMap[index] & mask) != 0);
     }
 
@@ -161,8 +161,8 @@ contract Bridgeless is
     function _createPartialFillStorage(BridgelessOrder calldata order, uint256 tokensTransferredOut, uint256 tokensObtained) internal {
         // set the storage slot
         bytes32 newOrderHash = calculateBridgelessOrderHash_PartialFill(order, tokensTransferredOut, tokensObtained);
-        uint256 index = (uint256(newOrderHash) >> 128);
-        uint256 mask = 1 << ((uint256(newOrderHash) & 0xffffffffffffffff));
+        uint256 index = (uint256(newOrderHash) >> 8);
+        uint256 mask = 1 << ((uint256(newOrderHash) & 0xff));
         partialFillOrderActiveBitMap[index] = (partialFillOrderActiveBitMap[index] | mask);
         // emit an event
         emit PartialFillStorageCreated(newOrderHash, order, tokensTransferredOut, tokensObtained);
@@ -418,8 +418,8 @@ contract Bridgeless is
         // calculate the orderHash
         bytes32 orderHash = calculateBridgelessOrderHash(order);
         // verify that `orderHash` is 'active' (i.e. its bit flag is set to '1' in the `partialFillOrderActiveBitMap`)
-        uint256 index = (uint256(orderHash) >> 128);
-        uint256 mask = 1 << ((uint256(orderHash) & 0xffffffffffffffff));
+        uint256 index = (uint256(orderHash) >> 8);
+        uint256 mask = 1 << ((uint256(orderHash) & 0xff));
         require(
             (partialFillOrderActiveBitMap[index] & mask != 0),
             "Bridgeless._markAsNoLongerActive: partialFillOrder not active at orderHash"

--- a/src/contracts/BridgelessOrderSignatures.sol
+++ b/src/contracts/BridgelessOrderSignatures.sol
@@ -23,8 +23,8 @@ abstract contract BridgelessOrderSignatures is
     mapping(address => mapping(uint256 => uint256)) public nonceBitmaps;
 
     function nonceIsSpent(address signer, uint256 nonce) public view returns (bool) {
-        uint256 index = (nonce >> 128);
-        uint256 mask = (1 << (nonce & 0xffffffffffffffff));
+        uint256 index = (nonce >> 8);
+        uint256 mask = (1 << (nonce & 0xff));
         return ((nonceBitmaps[signer][index] & mask) != 0);
     }
 
@@ -43,8 +43,8 @@ abstract contract BridgelessOrderSignatures is
         // verify the order signature
         _checkOrderSignature(order.signer, orderHash, signature);
         // check nonce validity
-        uint256 index = (order.nonce >> 128);
-        uint256 mask = (1 << (order.nonce & 0xffffffffffffffff));
+        uint256 index = (order.nonce >> 8);
+        uint256 mask = (1 << (order.nonce & 0xff));
         // this means the nonce is already spent
         if (nonceBitmaps[order.signer][index] & mask != 0) {
             revert("Bridgeless._processOrderSignature: nonce is already spent");

--- a/src/contracts/BridgelessOrderSignatures.sol
+++ b/src/contracts/BridgelessOrderSignatures.sol
@@ -23,9 +23,9 @@ abstract contract BridgelessOrderSignatures is
     mapping(address => mapping(uint256 => uint256)) public nonceBitmaps;
 
     function nonceIsSpent(address signer, uint256 nonce) public view returns (bool) {
-        uint256 index = nonce >> 8;
-        uint256 mask = 1 << (nonce & 0xff);
-        return nonceBitmaps[signer][index] & mask != 0;
+        uint256 index = (nonce >> 8);
+        uint256 mask = (1 << (nonce & 0xff));
+        return ((nonceBitmaps[signer][index] & mask) != 0);
     }
 
     // set immutable variables
@@ -43,8 +43,8 @@ abstract contract BridgelessOrderSignatures is
         // verify the order signature
         _checkOrderSignature(order.signer, orderHash, signature);
         // check nonce validity
-        uint256 index = order.nonce >> 8;
-        uint256 mask = 1 << (order.nonce & 0xff);
+        uint256 index = (order.nonce >> 8);
+        uint256 mask = (1 << (order.nonce & 0xff));
         // this means the nonce is already spent
         if (nonceBitmaps[order.signer][index] & mask != 0) {
             revert("Bridgeless._processOrderSignature: nonce is already spent");

--- a/src/contracts/BridgelessOrderSignatures.sol
+++ b/src/contracts/BridgelessOrderSignatures.sol
@@ -23,9 +23,9 @@ abstract contract BridgelessOrderSignatures is
     mapping(address => mapping(uint256 => uint256)) public nonceBitmaps;
 
     function nonceIsSpent(address signer, uint256 nonce) public view returns (bool) {
-        uint256 index = (nonce >> 8);
+        uint256 bucket = (nonce >> 8);
         uint256 mask = (1 << (nonce & 0xff));
-        return ((nonceBitmaps[signer][index] & mask) != 0);
+        return ((nonceBitmaps[signer][bucket] & mask) != 0);
     }
 
     // set immutable variables
@@ -43,14 +43,14 @@ abstract contract BridgelessOrderSignatures is
         // verify the order signature
         _checkOrderSignature(order.signer, orderHash, signature);
         // check nonce validity
-        uint256 index = (order.nonce >> 8);
+        uint256 bucket = (order.nonce >> 8);
         uint256 mask = (1 << (order.nonce & 0xff));
         // this means the nonce is already spent
-        if (nonceBitmaps[order.signer][index] & mask != 0) {
+        if (nonceBitmaps[order.signer][bucket] & mask != 0) {
             revert("Bridgeless._processOrderSignature: nonce is already spent");
         }
         // mark nonce as spent
-        nonceBitmaps[order.signer][index] = (nonceBitmaps[order.signer][index] | mask);
+        nonceBitmaps[order.signer][bucket] = (nonceBitmaps[order.signer][bucket] | mask);
     }
 
     /**

--- a/src/contracts/BridgelessOrderSignatures.sol
+++ b/src/contracts/BridgelessOrderSignatures.sol
@@ -23,8 +23,8 @@ abstract contract BridgelessOrderSignatures is
     mapping(address => mapping(uint256 => uint256)) public nonceBitmaps;
 
     function nonceIsSpent(address signer, uint256 nonce) public view returns (bool) {
-        uint256 index = (nonce >> 8);
-        uint256 mask = (1 << (nonce & 0xff));
+        uint256 index = (nonce >> 128);
+        uint256 mask = (1 << (nonce & 0xffffffffffffffff));
         return ((nonceBitmaps[signer][index] & mask) != 0);
     }
 
@@ -43,8 +43,8 @@ abstract contract BridgelessOrderSignatures is
         // verify the order signature
         _checkOrderSignature(order.signer, orderHash, signature);
         // check nonce validity
-        uint256 index = (order.nonce >> 8);
-        uint256 mask = (1 << (order.nonce & 0xff));
+        uint256 index = (order.nonce >> 128);
+        uint256 mask = (1 << (order.nonce & 0xffffffffffffffff));
         // this means the nonce is already spent
         if (nonceBitmaps[order.signer][index] & mask != 0) {
             revert("Bridgeless._processOrderSignature: nonce is already spent");

--- a/src/contracts/libraries/BridgelessOrderLibrary.sol
+++ b/src/contracts/libraries/BridgelessOrderLibrary.sol
@@ -18,6 +18,11 @@ abstract contract BridgelessOrderLibrary is
     bytes32 public constant ORDER_TYPEHASH = keccak256(
         "BridgelessOrder(address tokenIn,uint256 amountIn, address tokenOut,uint256 amountOutMin,uint256 deadline,uint256 noncebytes optionalParameters)");
 
+    // BIT MASKS
+    uint256 internal constant FIRST_BIT_MASK = 0x1000000000000000000000000000000000000000000000000000000000000000;
+    uint256 internal constant SECOND_BIT_MASK = 0x2000000000000000000000000000000000000000000000000000000000000000;
+    uint256 internal constant THIRD_BIT_MASK = 0x4000000000000000000000000000000000000000000000000000000000000000;
+
     /**
      * @notice Simple getter function to calculate the `orderHash` for a `BridgelessOrder`
      * @param order A `BridgelessOrder`-type order
@@ -41,13 +46,14 @@ abstract contract BridgelessOrderLibrary is
     }
 
     /**
-     * Experimental `optionalParameters` format is:
-     * (optional) bytes1: flags to indicate order types -- do not need to include (but can include) for "simple" orders
+     * @dev The `optionalParameters` format is:
+     * (optional) bytes1: 8-bit map of flags to indicate presence of optional parameters -- do not need to include (but can include) for "simple" orders
      * abi.encodePacked(additional args): for each flag that is a '1', additional calldata should be attached, encoding information relevant to that flag
      */
     function packOptionalParameters(
         bool usingExecutor,
         bool usingValidAfter,
+        bool usingPartialFill,
         address executor,
         uint32 validAfter
     ) public pure returns (bytes memory optionalParameters)
@@ -61,7 +67,7 @@ abstract contract BridgelessOrderLibrary is
             assembly {
                 mstore(
                     add(optionalParameters, 32),
-                    or(mload(add(optionalParameters, 32)), 0x1000000000000000000000000000000000000000000000000000000000000000)
+                    or(mload(add(optionalParameters, 32)), FIRST_BIT_MASK)
                 )
             }
         }
@@ -72,7 +78,16 @@ abstract contract BridgelessOrderLibrary is
             assembly {
                 mstore(
                     add(optionalParameters, 32),
-                    or(mload(add(optionalParameters, 32)), 0x2000000000000000000000000000000000000000000000000000000000000000)
+                    or(mload(add(optionalParameters, 32)), SECOND_BIT_MASK)
+                )
+            }
+        }
+        if (usingPartialFill) {
+            // partialFill flag is third bit being 1 -- set this bit!
+            assembly {
+                mstore(
+                    add(optionalParameters, 32),
+                    or(mload(add(optionalParameters, 32)), THIRD_BIT_MASK)
                 )
             }
         }
@@ -82,12 +97,12 @@ abstract contract BridgelessOrderLibrary is
     /**
      * @dev The `optionalParameters` format is:
      * (optional) bytes1: 8-bit map of flags to indicate presence of optional parameters -- do not need to include (but can include) for "simple" orders
-     * bytes: for each flag that is a '1', additional calldata should be attached, encoding information relevant to that flag
+     * abi.encodePacked(additional args): for each flag that is a '1', additional calldata should be attached, encoding information relevant to that flag
      */
     function unpackOptionalParameters(
         bytes memory optionalParameters
     )
-        public pure returns (bool usingExecutor, bool usingValidAfter, address executor, uint32 validAfter) {
+        public pure returns (bool usingExecutor, bool usingValidAfter, bool usingPartialFill, address executor, uint32 validAfter) {
         // account for the 32 bytes of data that encode length
         uint256 additionalOffset = 32;
         assembly {
@@ -95,23 +110,31 @@ abstract contract BridgelessOrderLibrary is
             usingExecutor := eq(
                 and(
                     mload(add(optionalParameters, additionalOffset)),
-                    0x1000000000000000000000000000000000000000000000000000000000000000
+                    FIRST_BIT_MASK
                 ),
-                    0x1000000000000000000000000000000000000000000000000000000000000000
+                    FIRST_BIT_MASK
             )
             // validAfter flag is second bit being 1 -- check for this flag
             usingValidAfter := eq(
                 and(
                     // offset of 32 is used to start reading from `optionalParameters` starting after the 32 bytes that encode length
                     mload(add(optionalParameters, additionalOffset)),
-                    0x2000000000000000000000000000000000000000000000000000000000000000
+                    SECOND_BIT_MASK
                 ),
-                    0x2000000000000000000000000000000000000000000000000000000000000000
+                    SECOND_BIT_MASK
+            )
+            // partialFill flag is third bit being 1 -- check for this flag
+            usingPartialFill := eq(
+                and(
+                    // offset of 32 is used to start reading from `optionalParameters` starting after the 32 bytes that encode length
+                    mload(add(optionalParameters, additionalOffset)),
+                    THIRD_BIT_MASK
+                ),
+                    THIRD_BIT_MASK
             )
             // add to additionalOffset to account for the 1 byte of data that was read
             additionalOffset := add(additionalOffset, 1)
         }
-        // run Executor check if flag was set
         if (usingExecutor) {
             assembly {
                 // read executor address -- address is 160 bits so we right-shift by (256-160) = 96
@@ -122,7 +145,6 @@ abstract contract BridgelessOrderLibrary is
                 additionalOffset := add(additionalOffset, 20)                    
             }          
         }
-        // run validAfter check if flag was set
         if (usingValidAfter) {
             assembly {
                 // read validAfter timestamp -- timestamp is enocoded as 32 bits so we right-shift by (256-32) = 224

--- a/src/contracts/libraries/BridgelessOrderLibrary.sol
+++ b/src/contracts/libraries/BridgelessOrderLibrary.sol
@@ -45,6 +45,30 @@ abstract contract BridgelessOrderLibrary is
         );
     }
 
+    function calculateBridgelessOrderHash_PartialFill(
+        BridgelessOrder calldata order,
+        uint256 tokensTransferredOut,
+        uint256 tokensObtained
+    )
+        public pure returns (bytes32)
+    {
+        return(
+            keccak256(
+                abi.encode(
+                    ORDER_TYPEHASH,
+                    order.signer,
+                    order.tokenIn,
+                    order.amountIn - tokensTransferredOut,
+                    order.tokenOut,
+                    order.amountOutMin - tokensObtained,
+                    order.deadline,
+                    order.nonce,
+                    order.optionalParameters
+                )
+            )
+        );
+    }
+
     /**
      * @dev The `optionalParameters` format is:
      * (optional) bytes1: 8-bit map of flags to indicate presence of optional parameters -- do not need to include (but can include) for "simple" orders

--- a/src/contracts/mocks/Bridgeless_AccessControlEnumerable.sol
+++ b/src/contracts/mocks/Bridgeless_AccessControlEnumerable.sol
@@ -27,8 +27,6 @@ contract Bridgeless_AccessControlEnumerable is
         onlyRole(DEFAULT_ADMIN_ROLE)
         // @dev Modifier to verify that order is still valid
         checkOrderDeadline(order.deadline)
-        // @dev Modifier to verify correct order execution
-        checkOrderFulfillment(order.signer, order.tokenOut, order.amountOutMin)
         // @dev nonReentrant modifier since we hand over control of execution to the aribtrary contract input `swapper` later in this function
         nonReentrant
     {

--- a/src/test/Tests.t.sol
+++ b/src/test/Tests.t.sol
@@ -169,7 +169,7 @@ contract Tests is
         // set up the order
         BridgelessOrder memory order;
         order = _makeOrder_Base(user);
-        order.optionalParameters = bridgeless.packOptionalParameters(true, false, address(multicall), _validAfter);
+        order.optionalParameters = bridgeless.packOptionalParameters(true, false, false, address(multicall), _validAfter);
         _doOrder(order);
     }
 
@@ -178,7 +178,7 @@ contract Tests is
         // set up the order
         BridgelessOrder memory order;
         order = _makeOrder_Base(user);
-        order.optionalParameters = bridgeless.packOptionalParameters(false, true, address(multicall), _validAfter);
+        order.optionalParameters = bridgeless.packOptionalParameters(false, true, false, address(multicall), _validAfter);
         _doOrder(order);
     }
 
@@ -188,7 +188,7 @@ contract Tests is
         // set up the order
         BridgelessOrder memory order;
         order = _makeOrder_Base(user);
-        order.optionalParameters = bridgeless.packOptionalParameters(true, true, address(multicall), _validAfter);
+        order.optionalParameters = bridgeless.packOptionalParameters(true, true, false, address(multicall), _validAfter);
         _doOrder(order);
     }
 
@@ -519,6 +519,7 @@ contract Tests is
     function testPackUnpackOptionalParameters(
         bool _usingExecutor,
         bool _usingValidAfter,
+        bool _usingPartialFill,
         address executor_,
         uint32 validAfter_
     )
@@ -526,20 +527,21 @@ contract Tests is
     {
         // deploy the Bridgeless contract
         bridgeless = new Bridgeless();
-        bytes memory optionalParameters = bridgeless.packOptionalParameters(_usingExecutor, _usingValidAfter, executor_, validAfter_);
-        (bool usingExecutor, bool usingValidAfter, address executor, uint32 validAfter) = 
+        bytes memory optionalParameters = bridgeless.packOptionalParameters(_usingExecutor, _usingValidAfter, _usingPartialFill, executor_, validAfter_);
+        (bool usingExecutor, bool usingValidAfter, bool usingPartialFill, address executor, uint32 validAfter) = 
             bridgeless.unpackOptionalParameters(optionalParameters);
         assertTrue(usingExecutor == _usingExecutor, "usingExecutor != _usingExecutor");
         assertTrue(usingValidAfter == _usingValidAfter, "usingValidAfter != _usingValidAfter");
+        assertTrue(usingPartialFill == _usingPartialFill, "usingPartialFill != _usingPartialFill");
         if (_usingExecutor) {
-            assertEq(executor, executor_);            
+            assertEq(executor_, executor);            
         } else {
-            assertEq(executor, address(0));            
+            assertEq(address(0), executor);            
         }
         if (_usingValidAfter) {
-            assertEq(validAfter, validAfter_);            
+            assertEq(validAfter_, validAfter);            
         } else {
-            assertEq(validAfter, uint32(0));            
+            assertEq(uint32(0), validAfter);            
         }
     }
 
@@ -547,7 +549,7 @@ contract Tests is
         // deploy the Bridgeless contract
         bridgeless = new Bridgeless();
         cheats.warp(_validAfter + 1);
-        bytes memory optionalParameters = bridgeless.packOptionalParameters(true, true, address(this), _validAfter);
+        bytes memory optionalParameters = bridgeless.packOptionalParameters(true, true, true, address(this), _validAfter);
         bridgeless.processOptionalParameters(optionalParameters);
     }
 }

--- a/src/test/utils/UsersAndSubmitter.sol
+++ b/src/test/utils/UsersAndSubmitter.sol
@@ -17,7 +17,7 @@ abstract contract UsersAndSubmitter is
     address[] public users;
     uint256[] public user_priv_keys;
 
-    constructor(uint8 numberUsers) {
+    function setUpUsers(uint8 numberUsers) public {
         user_priv_key = uint256(keccak256("pseudorandom-address-00"));
         user = payable(cheats.addr(user_priv_key));
         for (uint8 i; i < numberUsers; ++i) {


### PR DESCRIPTION
Adds support for partial fill orders. Currently only implemented for single-order fulfillment; I'd like to *at minimum* add support for multiple-order-fulfillment where some subset of the orders could be partial fills before merging this.

The `fulfillOrderFromStorage` function kind of pattern seems like it'll be awkward with multiple-order-fills; still need to sort out a good solution.

For *non-partial-fill* orders, this change is a minor gas increase due to slightly greater memory expansion and some small calculations, but I think it's worth it.